### PR TITLE
feat(exception): add global exception handling with custom error resp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,105 +1,120 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.example</groupId>
-	<artifactId>todoapp</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>todoapp</name>
-	<description>Demo project for Spring Boot</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>21</java.version>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.6</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>todoapp</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>todoapp</name>
+    <description>Demo project for Spring Boot</description>
+
+    <properties>
+        <java.version>21</java.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
-	</properties>
-	<dependencies>
+        <lombok.version>1.18.32</lombok.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- DB -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Devtools (opsiyonel) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- MapStruct runtime -->
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
         </dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
+        <!-- Lombok + MapStruct binding (KRİTİK) -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>0.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Derleyici ve annotation processors -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
                             <version>${mapstruct.version}</version>
                         </path>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
 
+            <!-- Spring Boot -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/example/todoapp/exception/DuplicateException.java
+++ b/src/main/java/com/example/todoapp/exception/DuplicateException.java
@@ -1,0 +1,7 @@
+package com.example.todoapp.exception;
+
+public class DuplicateException extends RuntimeException {
+    public DuplicateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/todoapp/exception/ErrorResponse.java
+++ b/src/main/java/com/example/todoapp/exception/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.example.todoapp.exception;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class ErrorResponse {
+    private LocalDateTime timestamp;
+    private int status;
+    private String error;
+    private String message;
+    private String path;
+
+    public ErrorResponse(HttpStatus status, String message, String path) {
+        this.timestamp = LocalDateTime.now();
+        this.status = status.value();
+        this.error = status.getReasonPhrase();
+        this.message = message;
+        this.path = path;
+    }
+
+    public static ErrorResponse of(HttpStatus status, String message, String path) {
+        return new ErrorResponse(status, message, path);
+    }
+}

--- a/src/main/java/com/example/todoapp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/todoapp/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.example.todoapp.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex, HttpServletRequest req) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(HttpStatus.NOT_FOUND, ex.getMessage(), req.getRequestURI()));
+    }
+
+    @ExceptionHandler(DuplicateException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicate(DuplicateException ex, HttpServletRequest req) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ErrorResponse.of(HttpStatus.CONFLICT, ex.getMessage(), req.getRequestURI()));
+    }
+
+    // İsteğe bağlı: beklenmeyen hatalar
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneric(Exception ex, HttpServletRequest req) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), req.getRequestURI()));
+    }
+}

--- a/src/main/java/com/example/todoapp/exception/NotFoundException.java
+++ b/src/main/java/com/example/todoapp/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.todoapp.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/todoapp/repos/TodoRepository.java
+++ b/src/main/java/com/example/todoapp/repos/TodoRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface TodoRepository extends JpaRepository<Todo,Long> {
     List<Todo> findByDone(boolean done);
+    boolean existsByTitle(String title);
 }

--- a/src/main/java/com/example/todoapp/services/impl/TodoServiceImpl.java
+++ b/src/main/java/com/example/todoapp/services/impl/TodoServiceImpl.java
@@ -4,6 +4,8 @@ import com.example.todoapp.dto.TodoCreateRequest;
 import com.example.todoapp.dto.TodoResponse;
 import com.example.todoapp.dto.TodoUpdateRequest;
 import com.example.todoapp.entities.Todo;
+import com.example.todoapp.exception.DuplicateException;
+import com.example.todoapp.exception.NotFoundException;
 import com.example.todoapp.mapper.TodoMapper;
 import com.example.todoapp.repos.TodoRepository;
 import com.example.todoapp.services.TodoService;
@@ -43,74 +45,100 @@ public class TodoServiceImpl implements TodoService {
 
     @Override
     public TodoResponse create(TodoCreateRequest req) {
-        // Request DTO → Entity
+        // 1. Aynı başlıkta bir şey var mı diye bak
+        if (repo.existsByTitle(req.getTitle())) {
+            // Varsa DuplicateException fırlat (409 Conflict)
+            throw new DuplicateException("Todo already exists with title: " + req.getTitle());
+        }
+
+        // 2. DTO → Entity çevir
         Todo entity = mapper.toEntity(req);
 
-        // DB'ye kaydet
+        // 3. Entity'yi veritabanına kaydet
         Todo saved = repo.save(entity);
 
-        // Entity → Response DTO
-        TodoResponse response = mapper.toResponse(saved);
-
-        return response;
+        // 4. Entity → Response DTO çevir ve geri döndür
+        return mapper.toResponse(saved);
     }
 
     @Override
     @Transactional(readOnly = true)
     public TodoResponse getById(Long id) {
+        // 1. ID ile veritabanında arama yap
         Optional<Todo> optional = repo.findById(id);
 
+        // 2. Eğer kayıt varsa al, yoksa NotFoundException fırlat
         if (optional.isPresent()) {
-            Todo entity = optional.get();
-            return mapper.toResponse(entity);
+            Todo todo = optional.get();
+            // 3. Entity → Response DTO dönüştür
+            return mapper.toResponse(todo);
+        } else {
+            throw new NotFoundException("Todo not found with id: " + id);
         }
-
-        // bulunamadıysa şimdilik null döner
-        return null;
     }
 
     @Override
     @Transactional
     public TodoResponse update(Long id, TodoUpdateRequest req) {
+        // 1. ID ile veritabanında arama yap
         Optional<Todo> optional = repo.findById(id);
 
         if (optional.isPresent()) {
+            // 2. Kayıt bulundu → entity'yi al
             Todo entity = optional.get();
+
+            // 3. DTO → entity güncellemesi yap
             mapper.updateEntityFromDto(req, entity);
 
+            // 4. Güncellenmiş entity'yi veritabanına kaydet
             Todo saved = repo.save(entity);
-            return mapper.toResponse(saved);
-        }
 
-        // bulunamadıysa şimdilik null döner
-        return null;
+            // 5. Entity → Response DTO dönüştür
+            return mapper.toResponse(saved);
+        } else {
+            // 6. Kayıt yoksa hata fırlat
+            throw new NotFoundException("Todo not found with id: " + id);
+        }
     }
 
     @Override
     @Transactional
     public void delete(Long id) {
-        // varsa sil, yoksa hiçbir şey yapma
-        if (repo.existsById(id)) {
+        // 1. ID veritabanında var mı diye kontrol et
+        boolean exists = repo.existsById(id);
+
+        if (exists) {
+            // 2. Varsa sil
             repo.deleteById(id);
+        } else {
+            // 3. Yoksa NotFoundException fırlat (404)
+            throw new NotFoundException("Todo not found with id: " + id);
         }
     }
 
     @Override
     @Transactional
     public TodoResponse toggleDone(Long id) {
+        // 1. ID ile veritabanında arama yap
         Optional<Todo> optional = repo.findById(id);
 
         if (optional.isPresent()) {
+            // 2. Kayıt bulundu → entity'yi al
             Todo entity = optional.get();
 
-            // mevcut değeri tersine çevir
+            // 3. mevcut "done" değerini tersine çevir
             boolean current = entity.isDone();
             entity.setDone(!current);
 
+            // 4. Güncellenmiş entity'yi kaydet
             Todo saved = repo.save(entity);
-            return mapper.toResponse(saved);
-        }
 
-        return null; // şimdilik bulunamadıysa null
+            // 5. Entity → Response DTO dönüştür
+            return mapper.toResponse(saved);
+        } else {
+            // 6. Kayıt bulunamadı → NotFoundException fırlat
+            throw new NotFoundException("Todo not found with id: " + id);
+        }
     }
+
 }


### PR DESCRIPTION
### Bu PR ile yapılanlar
- `GlobalExceptionHandler` eklendi (`@RestControllerAdvice`)
- `NotFoundException` (404) ve `DuplicateException` (409) sınıfları tanımlandı
- `ErrorResponse` objesi ile hata çıktıları standart hale getirildi
- Genel Exception handler eklendi (500 Internal Server Error)

### Neden
- API hata yönetimini merkezi hale getirmek
- İstemcilere daha anlaşılır ve tutarlı hata mesajları sağlamak

### Test Senaryoları
- `GET /todos/{id}` → geçersiz id → 404 Not Found
- `POST /todos` → aynı başlıkla todo ekleme → 409 Conflict
- Beklenmeyen hata → 500 Internal Server Error
